### PR TITLE
Creation of directory 'log' may fail

### DIFF
--- a/samples/communication_log_file_handler.py
+++ b/samples/communication_log_file_handler.py
@@ -26,5 +26,6 @@ class CommunicationLogFileHandler(logging.Handler):
 
     def emit(self, record):
         filename = os.path.join(self.path, "{}com_{}.log".format(self.prefix, record.remoteName))
-        with open(filename, 'a') as f:
+        os.makedirs(os.path.dirname(filename), exist_ok=True)        
+	with open(filename, 'a') as f:
             f.write(self.format(record) + "\n")

--- a/samples/communication_log_file_handler.py
+++ b/samples/communication_log_file_handler.py
@@ -27,5 +27,5 @@ class CommunicationLogFileHandler(logging.Handler):
     def emit(self, record):
         filename = os.path.join(self.path, "{}com_{}.log".format(self.prefix, record.remoteName))
         os.makedirs(os.path.dirname(filename), exist_ok=True)        
-	with open(filename, 'a') as f:
+        with open(filename, 'a') as f:
             f.write(self.format(record) + "\n")


### PR DESCRIPTION
Hi there,

I came across a little quirck, where the logfile creation failed as python was not able to create the folder 'log'. This behaviour could be observed on a Win 10 machine without elevated rights using python 3.8.3.

The provided solution requires Python 3.2 or higher as far as I know. Therfore there will be additional changes required, if you want to support lower versions as well. Please have a look.

Cheers