### PR TITLE
Fix not passing raw value in set ec value callback.

### DIFF
--- a/secsgem/gem/equipmenthandler.py
+++ b/secsgem/gem/equipmenthandler.py
@@ -827,7 +827,7 @@ class GemEquipmentHandler(GemHandler):
 
         if eac == 0:
             for ec in message:
-                self._set_ec_value(self._equipment_constants[ec.ECID], ec.ECV)
+                self._set_ec_value(self._equipment_constants[ec.ECID], ec.ECV.get())
 
         return self.stream_function(2, 16)(eac)
 


### PR DESCRIPTION
I tested set ec value. the set action was successful. Then when trying to retrieve the value back it trigger error due to trying to set String type with ECV. Probably need to fix the test script first before can merge. I havent look at the test script.