### PR TITLE
Fix to ensure serverSock close connection immediately.

### DIFF
--- a/secsgem/hsms/passive_connection.py
+++ b/secsgem/hsms/passive_connection.py
@@ -155,6 +155,7 @@ class HsmsPassiveConnection(HsmsConnection):  # pragma: no cover
             # start the receiver thread
             self._start_receiver()
 
+            self.serverSock.shutdown(socket.SHUT_RDWR)
             self.serverSock.close()
 
             return


### PR DESCRIPTION
Hi @bparzella,
This is a fix for issue I faced when client disconnected from server.
The serverSock cannot bind to the same address even after the SO_REUSEADDR opt was set.
This causes the client cannot reconnect to the server.

The [docs](https://docs.python.org/3/library/socket.html#socket.socket.close) point out that need to call shutdown before close to ensure connection close immediately.
Applying this resolve the issue on my side.