### PR TITLE
Fix wrong docstring in S6F11 handler

### DIFF
--- a/secsgem/gem/hosthandler.py
+++ b/secsgem/gem/hosthandler.py
@@ -221,7 +221,7 @@ class GemHostHandler(GemHandler):
     def _on_s06f11(self,
                    handler: secsgem.secs.SecsHandler,
                    message: secsgem.common.Message) -> secsgem.secs.SecsStreamFunction | None:
-        """Handle Stream 6, Function 11, Establish Communication Request.
+        """Handle Stream 6, Function 11, Event Report Send.
 
         Args:
             handler: handler the message was received on


### PR DESCRIPTION
"Establish Communication Request" is for S6F13 and not S6F11.