### PR TITLE
trigger_collection_events: Rely on correct type annotation

### DIFF
--- a/secsgem/gem/collection_event_capability.py
+++ b/secsgem/gem/collection_event_capability.py
@@ -117,10 +117,6 @@ class CollectionEventCapability(GemHandler, Capability):
         """
 
         def _ce_sender():
-            nonlocal ceids
-            if not isinstance(ceids, list):
-                ceids = [ceids]
-
             for ceid in ceids:
                 if isinstance(ceid, CollectionEventId):
                     ceid = ceid.value


### PR DESCRIPTION
ceids is a list according to the type annotation, let's rely on that.